### PR TITLE
Adding monitor type for createMonitor call

### DIFF
--- a/src/utils/cronjob.js
+++ b/src/utils/cronjob.js
@@ -9,5 +9,5 @@ export const parse = (job) => {
   const arr = job.split(' ');
   const schedule = arr.slice(0, 5).join(' ');
   const command = arr.slice(5).join(' ');
-  return { schedule, command }
+  return { schedule, command, type:'dual' }
 }


### PR DESCRIPTION
This is to add a type to the call to `createMonitor`, which is called when using `sundial discover`. There's more info in the [associated server PR](https://github.com/Sundial-Inc/server/pull/33). The assumption is that, if a user is using a `sundial` command to add monitors, then they should be `dual` type by default.

Screenshot is from the `monitor` table; the first two rows were created from using `sundial discover`.

![Screenshot 2023-10-27 at 1 50 28 PM](https://github.com/Sundial-Inc/cli/assets/10123446/af484645-9f72-4f8e-a9ad-a720b8f126f1)
