### PR TITLE
Remove console logs

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -3,7 +3,6 @@ import { generateRunToken } from '../utils/generateRunToken.js'
 import { pingMonitor } from '../services/api.js';
 
 export const run = async (program) => {
-  console.log('Start of a run!');
 
   // Store start ping info
   const time = new Date();
@@ -39,7 +38,6 @@ export const run = async (program) => {
 
     let event;
     if (code === 0) {
-      console.log('Command completed successfully');
       event = 'ending';
     } else {
       console.error(`Command failed with code ${code}`);
@@ -48,6 +46,5 @@ export const run = async (program) => {
 
     await pingMonitor(endPing, endpointKey, event);
 
-    console.log('End of a run!\n\n');
   });
 };

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -8,12 +8,10 @@ import {
 export const pingMonitor = async (ping, endpointKey, event) => {
   try {
     const URL = BASE_URL + PING_MONITOR + endpointKey + '?event=' + event
-    console.log(URL);
-    console.log(ping, event);
     const { data } = await axios.post(URL, ping);
     return data;
   } catch (e) {
-    console.log(e);
+    console.error(e);
   }
 };
 
@@ -22,6 +20,6 @@ export const createMonitor = async (newMonitor) => {
     const { data } = await axios.post(BASE_URL + CREATE_MONITOR, newMonitor);
     return data;
   } catch (e) {
-    console.log(e);
+    console.error(e);
   }
 };

--- a/src/utils/cronjob.js
+++ b/src/utils/cronjob.js
@@ -9,5 +9,5 @@ export const parse = (job) => {
   const arr = job.split(' ');
   const schedule = arr.slice(0, 5).join(' ');
   const command = arr.slice(5).join(' ');
-  return { schedule, command }
+  return { schedule, command, type:'dual' }
 }


### PR DESCRIPTION
Removing the console logs, since we know the CLI works now and it will write them to a file, if your cron job is to...write to a file.

![Screenshot 2023-10-27 at 3 42 48 PM](https://github.com/Sundial-Inc/cli/assets/10123446/1216b2f9-146f-4093-9841-bbc10b82de1a)

There are two `console.error`s – and if your job is to write to file, these might be printed there?