### PR TITLE
Removing base64 encoding

### DIFF
--- a/src/services/headers.js
+++ b/src/services/headers.js
@@ -17,7 +17,7 @@ export const getHeaders = () => {
   return {
     headers: {
       'X-Sync-Mode': 'CLI',
-      'Authorization': `Bearer ${btoa(apiKey)}`,
+      'Authorization': `Bearer ${apiKey}`,
     },
   };
 }


### PR DESCRIPTION
Since we're using `Bearer` for our authentication headers and not `Basic`, there's no need for encoding the api key in base64. This was a prerequisite for using `Basic` authentication, but not for `Bearer`.

I found out that `Bearer` did not need to be encoded based on these two pieces of information:

- [Blog post](https://georgearisty.dev/posts/oauth2-token-bearer-usage/#:~:text=Bearer%20tokens%20are%20laid%20bare,Base64%20in%20the%20Authorization%20header.)
- [bug discussion](https://github.com/strongloop/loopback/issues/1117) from some app that did encode them

It additionally needed to be removed because we weren't decoding on the server side, causing `sundial discover` to fail. Removing it does allow the command and route (POST /api/monitors) to work properly.